### PR TITLE
Deletion of Hospital Classification extension

### DIFF
--- a/Examples/Example-DataStandardsWales-Organization-GGH.xml
+++ b/Examples/Example-DataStandardsWales-Organization-GGH.xml
@@ -12,13 +12,6 @@
             <start value="2009-10-01" />
         </valuePeriod>
     </extension>
-    <extension url="https://fhir.nhs.wales/StructureDefinition/Extension-HospitalClassification">
-        <valueCoding>
-            <system value="https://fhir.nhs.wales/CodeSystem/HospitalClassification" />
-            <code value="B" />
-            <display value="Major acute hospital" />
-        </valueCoding>
-    </extension>
     <identifier>
         <system value="https://fhir.nhs.uk/Id/ods-organization-code" />
         <value value="7A2AG" />


### PR DESCRIPTION
Deletion of Organization.extension[1].url[0] as Hospital Classification deprecated DevOp: 13704