### PR TITLE
14283 Correct NamingSystems for BCU-Central PAS

### DIFF
--- a/NamingSystems/NamingSystem-BCU-Central-pas-identifier.xml
+++ b/NamingSystems/NamingSystem-BCU-Central-pas-identifier.xml
@@ -1,6 +1,6 @@
 <NamingSystem xmlns="http://hl7.org/fhir">
   <id value="DataStandardsWales-BCUHB-Central-PAS-Identifier"/> 
-  <name value="BCUHBCentralPasIdentifier"/>
+  <name value="BCUHBCentralPASIdentifier"/>
   <status value="active" />
   <kind value="identifier"/>   
   <date value="2023-08-02" />


### PR DESCRIPTION
14283  fixed inconsistency in NamingSystems/NamingSystem-BCU-Central-pas-identifier